### PR TITLE
Bump CircleCI setup_remote_docker and add Authentication using org-global context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,36 @@
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_dockerhub_login: &global_dockerhub_login
+  run:
+    name: Authenticate with hub.docker.com - DockerHub
+    command: docker login -u $GLOBAL_DOCKERHUB_USERNAME -p $GLOBAL_DOCKERHUB_PASSWORD
+global_context: &global_context
+  context:
+    - org-global
+global_remote_docker: &global_remote_docker
+  version: 19.03.13
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 defaults: &defaults
   working_directory: /multiruby
   docker:
     - image: deliveroo/circleci:0.2.8
-
+      <<: *global_dockerhub_auth
 version: 2
-
 jobs:
   build:
     <<: *defaults
-
     steps:
-
       - setup_remote_docker:
           reusable: true
           docker_layer_caching: true
-          version: 17.05.0-ce
-
+          <<: *global_remote_docker
+      - *global_dockerhub_login
       - checkout
-
       - run:
           name: Build production image
           command: ./build.sh
-
       - run:
           name: Save CI Image
           command: |
@@ -29,47 +38,38 @@ jobs:
             IMAGE=deliveroo/multiruby:$(cat VERSION)
             FILE=workspace/multiruby-$(cat VERSION).tar
             docker save "$IMAGE" --output "$FILE"
-
       - persist_to_workspace:
           root: workspace
           paths:
             - "*.tar"
-
   push:
     <<: *defaults
-
     steps:
-
       - add_ssh_keys:
           fingerprints:
             - 50:3a:87:a8:a6:5c:b7:58:3c:d2:71:b0:30:14:2c:a2
-
       - setup_remote_docker:
           reusable: true
           docker_layer_caching: true
-          version: 17.05.0-ce
-
+          <<: *global_remote_docker
+      - *global_dockerhub_login
       - checkout
-
       - attach_workspace:
           at: workspace
-
       - run:
           name: Load image
           command: |
             FILE=workspace/multiruby-$(cat VERSION).tar
             docker load --input "$FILE"
-
       - run:
           name: Tag the git commit and push the image
           command: ./tag_and_push.sh
-
 workflows:
   version: 2
-
   build_and_push:
     jobs:
-      - build
+      - build:
+          <<: *global_context
       - push:
           requires:
             - build
@@ -77,3 +77,4 @@ workflows:
             branches:
               only:
                 - master
+          <<: *global_context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ global_dockerhub_auth: &global_dockerhub_auth
 defaults: &defaults
   working_directory: /multiruby
   docker:
-    - image: deliveroo/circleci:0.2.8
+    - image: deliveroo/circleci:0.4.2
       <<: *global_dockerhub_auth
 version: 2
 jobs:


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

